### PR TITLE
prevent print set dtypes

### DIFF
--- a/bias_correction.py
+++ b/bias_correction.py
@@ -218,8 +218,8 @@ class XBiasCorrection(object):
         aa = self.mod_data
         if isinstance(aa, xr.Dataset):
             dtype = aa[list(aa.data_vars)[0]].dtype
-            print('No `dtype` chosen. Input is Dataset. \
-            Defaults to %s' % dtype)
+            # print('No `dtype` chosen. Input is Dataset. \
+            # Defaults to %s' % dtype)
         elif isinstance(aa, xr.DataArray):
             dtype = aa.dtype
         return dtype


### PR DESCRIPTION
@pankajkarman just a small change as I'd prefer to not get prints. Or shall we add a verbose argument for that instead?